### PR TITLE
Resend fix

### DIFF
--- a/packages/backend/convex/emails.ts
+++ b/packages/backend/convex/emails.ts
@@ -18,7 +18,7 @@ export const sendWelcomeEmail = internalMutation({
     const { email, name } = args;
 
     await resend.sendEmail(ctx, {
-      from: "Qurious <onboarding@resend.dev>", // TODO: Update with your actual domain
+      from: "Qurious <welcome@quriousai.xyz>",
       to: email,
       subject: "Welcome to Qurious! 🎉",
       html: `


### PR DESCRIPTION
Closes #72 
Closes #69 
Closes #64 

The bug was caused by a mismatch of DNS configurations and key settings between Convex, Resend and Vercel. There wasn't much wrong with the code except for the placeholder email.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the sender email address for welcome emails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->